### PR TITLE
Download and run Windows startup scripts from %USERPROFILE%\Downloads

### DIFF
--- a/startup/common.bat
+++ b/startup/common.bat
@@ -99,19 +99,21 @@ if %ERRORLEVEL% EQU 0 (
     REM Save current folder
     set "scriptPath=%~dp0"
     cd /d "%scriptPath%"
+    set "downloadDir=%USERPROFILE%\Downloads"
+    if not exist "%downloadDir%" mkdir "%downloadDir%"
 
     REM Bypass policy
     powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ^
     "Write-Host 'ExecutionPolicy set to Bypass'"
 
     REM Remove old tasks.ps1
-    if exist "%scriptPath%\tasks.ps1" del /s /q /f "%scriptPath%\tasks.ps1" 2>nul
-    if exist "%scriptPath%\import.ps1" del /s /q /f "%scriptPath%\import.ps1" 2>nul
+    if exist "%downloadDir%\tasks.ps1" del /s /q /f "%downloadDir%\tasks.ps1" 2>nul
+    if exist "%downloadDir%\import.ps1" del /s /q /f "%downloadDir%\import.ps1" 2>nul
 
     REM Download latest tasks.ps1
     where curl >nul 2>&1
     if %ERRORLEVEL% EQU 0 (
-        curl -L -o "%scriptPath%\tasks.ps1" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/tasks.ps1"
+        curl -L -o "%downloadDir%\tasks.ps1" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/tasks.ps1"
     ) else (
         @REM if exist "%ProgramFiles%\Unix\wget.exe" (
         @REM     "%ProgramFiles%\Unix\wget.exe" -O tasks.ps1 "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/tasks.ps1"
@@ -121,7 +123,7 @@ if %ERRORLEVEL% EQU 0 (
     REM Download latest import.ps1
     where curl >nul 2>&1
     if %ERRORLEVEL% EQU 0 (
-        curl -L -o "%scriptPath%\import.ps1" "https://raw.githubusercontent.com/Zerohazard8x/wifi/main/import.ps1"
+        curl -L -o "%downloadDir%\import.ps1" "https://raw.githubusercontent.com/Zerohazard8x/wifi/main/import.ps1"
     ) else (
         @REM if exist "%ProgramFiles%\Unix\wget.exe" (
         @REM     "%ProgramFiles%\Unix\wget.exe" -O import.ps1 "https://raw.githubusercontent.com/Zerohazard8x/wifi/main/import.ps1"
@@ -129,18 +131,18 @@ if %ERRORLEVEL% EQU 0 (
     )
 
     REM Run tasks.ps1 if present
-    if exist "%scriptPath%\tasks.ps1" (
-        powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%scriptPath%\tasks.ps1"
+    if exist "%downloadDir%\tasks.ps1" (
+        powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%downloadDir%\tasks.ps1"
     )
 
     REM Run import.ps1 if present
-    if exist "%scriptPath%\import.ps1" (
-        powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%scriptPath%\import.ps1"
+    if exist "%downloadDir%\import.ps1" (
+        powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%downloadDir%\import.ps1"
     )
 
     REM Check for private script
-    if exist "%scriptPath%\import_private.ps1" (
-        powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%scriptPath%\import_private.ps1"
+    if exist "%downloadDir%\import_private.ps1" (
+        powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%downloadDir%\import_private.ps1"
     )
 
     REM Restore default execution policy

--- a/startup/downloader.bat
+++ b/startup/downloader.bat
@@ -1,43 +1,45 @@
 @echo off
-del /s /q /f .\common.bat
-del /s /q /f .\startup_tasks.bat
+set "downloadDir=%USERPROFILE%\Downloads"
+if not exist "%downloadDir%" mkdir "%downloadDir%"
+del /s /q /f "%downloadDir%\common.bat"
+del /s /q /f "%downloadDir%\startup_tasks.bat"
 
 where curl >nul 2>&1
 if %errorlevel% equ 0 (
-    curl --remote-time -C - -L --output-dir "." -O "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
+    curl --remote-time -C - -L --output-dir "%downloadDir%" -O "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
 ) else (
     where wget >nul 2>&1
     if %errorlevel% equ 0 (
-        wget -c --timestamping "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
+        wget -c --timestamping -O "%downloadDir%\common.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
     ) else (
         where aria2c >nul 2>&1
         if %errorlevel% equ 0 (
-            aria2c -R --allow-overwrite=true "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
+            aria2c -R --allow-overwrite=true -d "%downloadDir%" -o "common.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
         )
     )
 )
 
-if exist ".\common.bat" (
-    findstr /C:"minescule" /C:"mouse" ".\common.bat" >nul 2>&1
+if exist "%downloadDir%\common.bat" (
+    findstr /C:"minescule" /C:"mouse" "%downloadDir%\common.bat" >nul 2>&1
     if %errorlevel% equ 0 (
         where curl >nul 2>&1
         if %errorlevel% equ 0 (
-            curl --remote-time -C - -LO "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks.bat"
+            curl --remote-time -C - -L --output-dir "%downloadDir%" -O "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks.bat"
         ) else (
             where wget >nul 2>&1
             if %errorlevel% equ 0 (
-                wget -c --timestamping "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks.bat"
+                wget -c --timestamping -O "%downloadDir%\startup_tasks.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks.bat"
             ) else (
                 where aria2c >nul 2>&1
                 if %errorlevel% equ 0 (
-                    aria2c -R --allow-overwrite=true "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks.bat"
+                    aria2c -R --allow-overwrite=true -d "%downloadDir%" -o "startup_tasks.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks.bat"
                 )
             )
         )
         
-        findstr /C:"minescule" /C:"mouse" ".\startup_tasks.bat" >nul 2>&1
+        findstr /C:"minescule" /C:"mouse" "%downloadDir%\startup_tasks.bat" >nul 2>&1
         if %errorlevel% equ 0 (
-            call ".\startup_tasks.bat"
+            call "%downloadDir%\startup_tasks.bat"
             exit
         )
     )

--- a/startup/downloader_lite.bat
+++ b/startup/downloader_lite.bat
@@ -1,43 +1,45 @@
 @echo off
-del /s /q /f .\common.bat
-del /s /q /f .\startup_tasks_lite.bat
+set "downloadDir=%USERPROFILE%\Downloads"
+if not exist "%downloadDir%" mkdir "%downloadDir%"
+del /s /q /f "%downloadDir%\common.bat"
+del /s /q /f "%downloadDir%\startup_tasks_lite.bat"
 
 where curl >nul 2>&1
 if %errorlevel% equ 0 (
-    curl --remote-time -C - -LO "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
+    curl --remote-time -C - -L --output-dir "%downloadDir%" -O "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
 ) else (
     where wget >nul 2>&1
     if %errorlevel% equ 0 (
-        wget -c --timestamping "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
+        wget -c --timestamping -O "%downloadDir%\common.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
     ) else (
         where aria2c >nul 2>&1
         if %errorlevel% equ 0 (
-            aria2c -R --allow-overwrite=true "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
+            aria2c -R --allow-overwrite=true -d "%downloadDir%" -o "common.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/common.bat"
         )
     )
 )
 
-if exist ".\common.bat" (
-    findstr /C:"minescule" /C:"mouse" ".\common.bat" >nul 2>&1
+if exist "%downloadDir%\common.bat" (
+    findstr /C:"minescule" /C:"mouse" "%downloadDir%\common.bat" >nul 2>&1
     if %errorlevel% equ 0 (
         where curl >nul 2>&1
         if %errorlevel% equ 0 (
-            curl --remote-time -C - -LO "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks_lite.bat"
+            curl --remote-time -C - -L --output-dir "%downloadDir%" -O "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks_lite.bat"
         ) else (
             where wget >nul 2>&1
             if %errorlevel% equ 0 (
-                wget -c --timestamping "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks_lite.bat"
+                wget -c --timestamping -O "%downloadDir%\startup_tasks_lite.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks_lite.bat"
             ) else (
                 where aria2c >nul 2>&1
                 if %errorlevel% equ 0 (
-                    aria2c -R --allow-overwrite=true "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks_lite.bat"
+                    aria2c -R --allow-overwrite=true -d "%downloadDir%" -o "startup_tasks_lite.bat" "https://raw.githubusercontent.com/Zerohazard8x/scripts/main/startup/startup_tasks_lite.bat"
                 )
             )
         )
         
-        findstr /C:"minescule" /C:"mouse" ".\startup_tasks_lite.bat" >nul 2>&1
+        findstr /C:"minescule" /C:"mouse" "%downloadDir%\startup_tasks_lite.bat" >nul 2>&1
         if %errorlevel% equ 0 (
-            call ".\startup_tasks_lite.bat"
+            call "%downloadDir%\startup_tasks_lite.bat"
             exit
         )
     )


### PR DESCRIPTION
### Motivation

- Ensure all Windows startup/downloader scripts store and execute downloaded helper scripts from the user `Downloads` folder instead of the script working directory.
- Reduce clutter in arbitrary script folders and centralize temporary helper files under `%USERPROFILE%\Downloads`.
- Make downloader behavior consistent across `curl`, `wget`, and `aria2c` usage.

### Description

- Updated `startup/common.bat` to set `downloadDir=%USERPROFILE%\Downloads`, create it if missing, remove old `tasks.ps1`/`import.ps1` from that folder, download the latest copies into `Downloads`, and execute them from `Downloads`.
- Updated `startup/downloader.bat` and `startup/downloader_lite.bat` to set `downloadDir=%USERPROFILE%\Downloads`, remove prior files from that folder, fetch `common.bat` and the appropriate `startup_tasks*.bat` into `Downloads`, and call the downloaded task scripts from `Downloads`.
- Adjusted invocations for `curl`, `wget`, and `aria2c` to write to the `Downloads` directory using `--output-dir`, `-O "%downloadDir%\<file>"`, or `-d`/`-o` as appropriate.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958bbb85cc083238e561b73411c531b)