### PR TITLE
Run startup terminal script chain at lowest practical priority

### DIFF
--- a/startup/common.bat
+++ b/startup/common.bat
@@ -1,4 +1,9 @@
 @echo off
+if /I not "%SCRIPT_LOWPRIO%"=="1" (
+    set "SCRIPT_LOWPRIO=1"
+    start "" /b /wait /low cmd /c ""%~f0" %*"
+    exit /b %errorlevel%
+)
 setlocal EnableExtensions EnableDelayedExpansion
 
 @REM version string

--- a/startup/downloader.bat
+++ b/startup/downloader.bat
@@ -1,4 +1,9 @@
 @echo off
+if /I not "%SCRIPT_LOWPRIO%"=="1" (
+    set "SCRIPT_LOWPRIO=1"
+    start "" /b /wait /low cmd /c ""%~f0" %*"
+    exit /b %errorlevel%
+)
 set "downloadDir=%USERPROFILE%\Downloads"
 if not exist "%downloadDir%" mkdir "%downloadDir%"
 del /s /q /f "%downloadDir%\common.bat"

--- a/startup/startup_tasks.bat
+++ b/startup/startup_tasks.bat
@@ -1,4 +1,9 @@
 @echo off
+if /I not "%SCRIPT_LOWPRIO%"=="1" (
+    set "SCRIPT_LOWPRIO=1"
+    start "" /b /wait /low cmd /c ""%~f0" %*"
+    exit /b %errorlevel%
+)
 
 REM -------------------------------------------------------------------
 REM version string
@@ -116,7 +121,7 @@ REM Finally, run common.bat (in a new window), wait, and capture its exit code
 REM -------------------------------------------------------------------
 if exist "common.bat" (
     REM Use START /WAIT with cmd /c so we get the real ERRORLEVEL from the child .bat
-    start "" /wait cmd /c common.bat
+    start "" /wait /low cmd /c common.bat
     set "rc=%errorlevel%"
 ) else (
     echo *** ERROR: common.bat not found! ***

--- a/startup/startup_tasks_lite.bat
+++ b/startup/startup_tasks_lite.bat
@@ -1,4 +1,9 @@
 @echo off
+if /I not "%SCRIPT_LOWPRIO%"=="1" (
+    set "SCRIPT_LOWPRIO=1"
+    start "" /b /wait /low cmd /c ""%~f0" %*"
+    exit /b %errorlevel%
+)
 
 REM -------------------------------------------------------------------
 REM version string
@@ -88,7 +93,7 @@ REM Finally, run common.bat (in a new window), wait, and capture its exit code
 REM -------------------------------------------------------------------
 if exist "common.bat" (
     REM Use START /WAIT with cmd /c so we get the real ERRORLEVEL from the child .bat
-    start "" /wait cmd /c common.bat
+    start "" /wait /low cmd /c common.bat
     set "rc=%errorlevel%"
 ) else (
     echo *** ERROR: common.bat not found! ***

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,3 +1,30 @@
+function Set-LowestProcessPriority {
+	$signature = @"
+using System;
+using System.Runtime.InteropServices;
+public static class NativePriority {
+    [DllImport("ntdll.dll")]
+    public static extern int NtSetInformationProcess(IntPtr processHandle, int processInformationClass, ref int processInformation, int processInformationLength);
+}
+"@
+
+	try {
+		Add-Type -TypeDefinition $signature -ErrorAction SilentlyContinue | Out-Null
+		$proc = [System.Diagnostics.Process]::GetCurrentProcess()
+		$proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::Idle
+		$proc.PriorityBoostEnabled = $false
+
+		$ioPriorityVeryLow = 0
+		$pagePriorityVeryLow = 1
+		[void][NativePriority]::NtSetInformationProcess($proc.Handle, 33, [ref]$ioPriorityVeryLow, 4)
+		[void][NativePriority]::NtSetInformationProcess($proc.Handle, 39, [ref]$pagePriorityVeryLow, 4)
+	}
+	catch {
+		Write-Verbose "Could not force lowest process priority settings: $_"
+	}
+}
+
+Set-LowestProcessPriority
 # Ensure the script runs with administrative privileges
 if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
 	Write-Warning "run this script as admin"


### PR DESCRIPTION
### Motivation
- Reduce the impact of the startup terminal chain so the scripts and any child processes they spawn run with the lowest practical CPU and I/O scheduling priority. 
- Ensure the downloader → startup_tasks → common → tasks chain demotes itself automatically so it does not steal foreground CPU from interactive apps.

### Description
- Add a low-priority self-relaunch guard to `startup/downloader.bat`, `startup/startup_tasks.bat`, `startup/startup_tasks_lite.bat`, and `startup/common.bat` that re-executes the calling `.bat` under `start /low` while avoiding recursion via the `SCRIPT_LOWPRIO` flag. 
- Force the link from the startup tasks to `common.bat` to use `start "" /wait /low cmd /c common.bat` so the next stage runs at low CPU priority as well. 
- Add `Set-LowestProcessPriority` to `tasks.ps1` to set the PowerShell process to `Idle` priority, disable priority boosting, and attempt very-low I/O / low page priority via `NtSetInformationProcess` as a best-effort hardening. 
- Tidy up leading whitespace in `tasks.ps1` so the priority function runs early in script execution.

### Testing
- Verified presence of the low-priority guard and adjusted `start ... /low` invocations with `rg -n "SCRIPT_LOWPRIO|start \"\" /wait /low cmd /c common.bat|Set-LowestProcessPriority|NtSetInformationProcess"`, which returned the expected hits. 
- Reviewed the code changes with a diff to confirm the inserted guard block and the `Set-LowestProcessPriority` function appear at the top of each target file. 
- Confirmed repository status changes with `git status --short` to ensure the intended files were modified and ready for review. 
- Tools used: 2/10 (`exec_command`, `make_pr`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7697691488323999a88f74d618209)