### PR TITLE
Cleanup downloaded batch/PowerShell artifacts after chain completion

### DIFF
--- a/startup/downloader.bat
+++ b/startup/downloader.bat
@@ -4,6 +4,7 @@ if /I not "%SCRIPT_LOWPRIO%"=="1" (
     start "" /b /wait /low cmd /c ""%~f0" %*"
     exit /b %errorlevel%
 )
+setlocal EnableExtensions
 set "downloadDir=%USERPROFILE%\Downloads"
 if not exist "%downloadDir%" mkdir "%downloadDir%"
 del /s /q /f "%downloadDir%\common.bat"
@@ -49,7 +50,18 @@ if exist "%downloadDir%\common.bat" (
         findstr /C:"minescule" /C:"mouse" "%downloadDir%\startup_tasks.bat" >nul 2>&1
         if %errorlevel% equ 0 (
             call "%downloadDir%\startup_tasks.bat"
-            exit
+            set "rc=%errorlevel%"
+            goto :cleanup
         )
     )
 )
+
+set "rc=1"
+
+:cleanup
+del /s /q /f "%downloadDir%\common.bat" 2>nul
+del /s /q /f "%downloadDir%\startup_tasks.bat" 2>nul
+del /s /q /f "%downloadDir%\tasks.ps1" 2>nul
+del /s /q /f "%downloadDir%\import.ps1" 2>nul
+del /s /q /f "%downloadDir%\import_private.ps1" 2>nul
+endlocal & exit /b %rc%

--- a/startup/downloader_lite.bat
+++ b/startup/downloader_lite.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal EnableExtensions
 set "downloadDir=%USERPROFILE%\Downloads"
 if not exist "%downloadDir%" mkdir "%downloadDir%"
 del /s /q /f "%downloadDir%\common.bat"
@@ -44,7 +45,18 @@ if exist "%downloadDir%\common.bat" (
         findstr /C:"minescule" /C:"mouse" "%downloadDir%\startup_tasks_lite.bat" >nul 2>&1
         if %errorlevel% equ 0 (
             call "%downloadDir%\startup_tasks_lite.bat"
-            exit
+            set "rc=%errorlevel%"
+            goto :cleanup
         )
     )
 )
+
+set "rc=1"
+
+:cleanup
+del /s /q /f "%downloadDir%\common.bat" 2>nul
+del /s /q /f "%downloadDir%\startup_tasks_lite.bat" 2>nul
+del /s /q /f "%downloadDir%\tasks.ps1" 2>nul
+del /s /q /f "%downloadDir%\import.ps1" 2>nul
+del /s /q /f "%downloadDir%\import_private.ps1" 2>nul
+endlocal & exit /b %rc%


### PR DESCRIPTION
### Motivation

- The downloader entrypoints fetched temporary chain scripts into the user's `Downloads` folder but did not remove them after the chain completed. 
- Leave no transient `.bat`/`.ps1` artifacts behind and ensure the wrapper returns the child script's exit code.

### Description

- Added `setlocal EnableExtensions` to the top of both `startup/downloader.bat` and `startup/downloader_lite.bat`. 
- Capture the exit code from the invoked chain script (`startup_tasks.bat` / `startup_tasks_lite.bat`) and jump to a centralized `:cleanup` block. 
- Remove downloaded artifacts from `%USERPROFILE%\Downloads` (`common.bat`, `startup_tasks*.bat`, `tasks.ps1`, `import.ps1`, `import_private.ps1`) in the `:cleanup` block and exit with the preserved return code. 

### Testing

- Listed repository files with `rg --files` to confirm the target scripts existed and were updated, and the command succeeded. 
- Printed and reviewed script contents with `sed -n` and `nl -ba` to verify the new `:cleanup` block, exit-code capture, and deletion commands were present, and those inspections succeeded. 
- Verified the produced file diffs show the added `setlocal`, centralized cleanup, artifact deletions, and exit propagation, and the diff check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd1bb944c8323bc1ad8906ea0ccdf)