### PR TITLE
Add elevation helpers and auto-elevation for admin tasks in startup scripts

### DIFF
--- a/startup/common.bat
+++ b/startup/common.bat
@@ -6,6 +6,12 @@ if /I not "%SCRIPT_LOWPRIO%"=="1" (
 )
 setlocal EnableExtensions EnableDelayedExpansion
 
+set "COMMON_ADMIN_STAGE="
+if /I "%~1"=="--admin-powershell" set "COMMON_ADMIN_STAGE=powershell"
+if /I "%~1"=="--admin-services" set "COMMON_ADMIN_STAGE=services"
+if /I "%COMMON_ADMIN_STAGE%"=="powershell" goto ADMIN_POWERSHELL_REPAIR
+if /I "%COMMON_ADMIN_STAGE%"=="services" goto ADMIN_SERVICE_TWEAKS
+
 @REM version string
 @REM minescule mouse
 
@@ -143,6 +149,17 @@ cls
 choice /C YN /N /D Y /T 15 /M "Powershell n Repair? (Y/N)"
 if errorlevel 2 goto NOPSHELL
 
+call :IsAdmin
+if "%errorlevel%"=="0" goto ADMIN_POWERSHELL_REPAIR
+
+call :RunElevatedStage powershell
+set "rc=%errorlevel%"
+if not "%rc%"=="0" (
+	endlocal & exit /b %rc%
+)
+goto NOPSHELL
+
+:ADMIN_POWERSHELL_REPAIR
 @REM dns config part 1
 @REM Enable DoH
 netsh dns add global doh=yes ddr=yes
@@ -223,12 +240,25 @@ bcdedit /set TESTSIGNING OFF
 bcdedit /set NOINTEGRITYCHECKS OFF
 bcdedit /set hypervisorlaunchtype auto
 
+if /I "%COMMON_ADMIN_STAGE%"=="powershell" endlocal & exit /b %errorlevel%
+
 :NOPSHELL
 
 cls
 choice /C YN /N /D N /T 15 /M "Service tweaks? (Y/N)"
 if errorlevel 2 goto NOSERVTWEAKS
 
+call :IsAdmin
+if "%errorlevel%"=="0" goto ADMIN_SERVICE_TWEAKS
+
+call :RunElevatedStage services
+set "rc=%errorlevel%"
+if not "%rc%"=="0" (
+	endlocal & exit /b %rc%
+)
+goto NOSERVTWEAKS
+
+:ADMIN_SERVICE_TWEAKS
 REM -------------------------------------------------------------------
 REM Configure and start key services (automatic)
 REM -------------------------------------------------------------------
@@ -248,6 +278,8 @@ REM -------------------------------------------------------------------
 @REM sc config "SysMain" start=disabled >nul 2>&1
 @REM sc config "svsvc" start=disabled >nul 2>&1
 
+if /I "%COMMON_ADMIN_STAGE%"=="services" endlocal & exit /b %errorlevel%
+
 :NOSERVTWEAKS
 
 control update
@@ -258,3 +290,19 @@ start "" "steam://open/downloads"
 endlocal
 choice /C YN /N /T 15 /D N /M "Stay open? (Y/N)"
 if errorlevel 2 exit 0
+cmd /k
+exit /b %errorlevel%
+
+:IsAdmin
+fltmc >nul 2>&1
+exit /b %errorlevel%
+
+:RunElevatedStage
+set "COMMON_ELEVATE_STAGE=%~1"
+call :IsAdmin
+if "%errorlevel%"=="0" exit /b 0
+
+echo Requesting administrator approval for %COMMON_ELEVATE_STAGE% tasks...
+set "SCRIPT_ELEVATE_TARGET=%~f0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$stageArg = '--admin-' + $env:COMMON_ELEVATE_STAGE; $p = Start-Process -FilePath $env:SCRIPT_ELEVATE_TARGET -ArgumentList $stageArg -Verb RunAs -Wait -PassThru; exit $p.ExitCode"
+exit /b %errorlevel%

--- a/startup/startup_tasks.bat
+++ b/startup/startup_tasks.bat
@@ -5,6 +5,7 @@ if /I not "%SCRIPT_LOWPRIO%"=="1" (
     exit /b %errorlevel%
 )
 setlocal EnableExtensions
+
 set "downloadDir=%USERPROFILE%\Downloads"
 if not exist "%downloadDir%" mkdir "%downloadDir%"
 
@@ -29,7 +30,7 @@ REM -------------------------------------------------------------------
 REM If Chocolatey exists, upgrade Python via choco
 REM -------------------------------------------------------------------
 where choco >nul 2>&1 && (
-    choco uninstall python2 python -y && choco upgrade python3 -y
+    call :RunElevatedCommand choco uninstall python2 python -y ^&^& choco upgrade python3 -y
 )
 
 REM -------------------------------------------------------------------
@@ -91,8 +92,7 @@ REM -------------------------------------------------------------------
 REM Upgrade Chocolatey packages
 REM -------------------------------------------------------------------
 where choco >nul 2>&1 && (
-    choco upgrade chocolatey curl firefox ffmpeg git jq mpv nomacs peazip phantomjs vlc -y
-    choco upgrade 7zip aria2 adb dos2unix nano scrcpy vscode thunderbird -y
+    call :RunElevatedCommand choco upgrade chocolatey curl firefox ffmpeg git jq mpv nomacs peazip phantomjs vlc -y ^&^& choco upgrade 7zip aria2 adb dos2unix nano scrcpy vscode thunderbird -y
 )
 
 REM where wsl >nul 2>&1 && (
@@ -127,4 +127,21 @@ REM Success path: auto-close unless user presses Y within 15 seconds
 choice /C YN /N /T 15 /D N /M "Stay open? (Y/N)"
 if errorlevel 2 endlocal & exit /b 0
 cmd /k
+endlocal & exit /b %errorlevel%
 REM =========================================================
+
+:IsAdmin
+fltmc >nul 2>&1
+exit /b %errorlevel%
+
+:RunElevatedCommand
+set "SCRIPT_ELEVATED_COMMAND=%*"
+call :IsAdmin
+if "%errorlevel%"=="0" (
+    cmd /d /c "%SCRIPT_ELEVATED_COMMAND%"
+    exit /b %errorlevel%
+)
+
+echo Requesting administrator approval for: %SCRIPT_ELEVATED_COMMAND%
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $env:SCRIPT_ELEVATED_COMMAND) -Verb RunAs -Wait -PassThru; exit $p.ExitCode"
+exit /b %errorlevel%

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -30,10 +30,43 @@ public static class NativePriority {
 }
 
 Set-LowestProcessPriority
-# Ensure the script runs with administrative privileges
-if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-	Write-Warning "run this script as admin"
-	exit
+function Test-IsAdministrator {
+	$currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+	$currentPrincipal = [Security.Principal.WindowsPrincipal] $currentIdentity
+
+	return $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Start-ElevatedSelf {
+	if ([string]::IsNullOrWhiteSpace($PSCommandPath)) {
+		throw 'Cannot relaunch the current script because PSCommandPath is empty.'
+	}
+
+	$escapedScriptPath = $PSCommandPath.Replace('"', '\"')
+	$argumentLine = '-NoProfile -ExecutionPolicy Bypass -File "{0}"' -f $escapedScriptPath
+	if ($args.Count -gt 0) {
+		$argumentLine = $argumentLine + ' ' + ($args -join ' ')
+	}
+
+	$process = Start-Process -FilePath 'powershell.exe' -ArgumentList $argumentLine -Verb RunAs -Wait -PassThru
+	if ($null -ne $process.ExitCode) {
+		exit $process.ExitCode
+	}
+
+	exit 0
+}
+
+# Ensure the script runs with administrative privileges. If it was launched from
+# a non-elevated scheduled task, ask Windows for elevation instead of failing.
+if (-not (Test-IsAdministrator)) {
+	Write-Warning 'Requesting administrator approval for tasks.ps1...'
+	try {
+		Start-ElevatedSelf @args
+	}
+	catch {
+		Write-Error "Could not relaunch tasks.ps1 as administrator: $_"
+		exit 1
+	}
 }
 
 # --- Error handling defaults ---


### PR DESCRIPTION
### Motivation

- Ensure operations that require administrator privileges (PowerShell repair steps, service tweaks, and package manager operations) can request elevation instead of failing silently. 
- Centralize and standardize elevation checks and prompts across batch and PowerShell startup scripts to simplify control flow and improve user experience. 

### Description

- Add admin-stage parsing and conditional branches to `startup/common.bat` including `--admin-powershell` and `--admin-services` handling, and implement `:IsAdmin` and `:RunElevatedStage` helpers to relaunch the script elevated when needed. 
- Update `startup/startup_tasks.bat` to provide `:IsAdmin` and `:RunElevatedCommand`, replace direct `choco` invocations with `call :RunElevatedCommand ...` to perform package operations under elevation, and tidy exit/`endlocal` behavior. 
- Modify `tasks.ps1` to add `Test-IsAdministrator` and `Start-ElevatedSelf` functions and to relaunch the current PowerShell script elevated (using `-Verb RunAs`) when not already running as administrator. 

### Testing

- No automated tests were added or run for this change in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a7feaa98c8323825ee477e2649465)