### PR TITLE
Reduce startup task console windows

### DIFF
--- a/startup/startup_tasks.bat
+++ b/startup/startup_tasks.bat
@@ -1,10 +1,10 @@
 @echo off
-if /I not "%SCRIPT_LOWPRIO%"=="1" (
-    set "SCRIPT_LOWPRIO=1"
-    @REM start "" /b /wait /low /min cmd /s /c ""%~f0" %*"
-    start "" /b /wait /min cmd /s /c ""%~f0" %*"
-    exit /b %errorlevel%
-)
+@REM Process priority relaunch is kept commented because spawning cmd.exe here creates another console window in the Task Scheduler chain.
+@REM if /I not "%SCRIPT_LOWPRIO%"=="1" (
+@REM     set "SCRIPT_LOWPRIO=1"
+@REM     start "" /b /wait /low /min cmd /s /c ""%~f0" %*"
+@REM     exit /b %errorlevel%
+@REM )
 setlocal EnableExtensions
 set "PIP_BREAK_SYSTEM_PACKAGES=1"
 
@@ -125,11 +125,11 @@ if /I "%STARTUP_ADMIN_STAGE%"=="programs" endlocal & exit /b %errorlevel%
 
 :NOPROGRAMS
 
-@REM Finally, run common.bat (in a new window), wait, and capture its exit code
+@REM Finally, run common.bat in the current console, wait, and capture its exit code.
 if exist "%downloadDir%\common.bat" (
-    @REM Use START /WAIT with cmd /c so we get the real ERRORLEVEL from the child .bat
+    @REM Process priority relaunch is kept commented because START /WAIT with cmd.exe creates another console window.
     @REM start "" /wait /low /min cmd /c "%downloadDir%\common.bat"
-    start "" /wait /min cmd /c "%downloadDir%\common.bat"
+    call "%downloadDir%\common.bat"
     set "rc=%errorlevel%"
 ) else (
     echo *** ERROR: common.bat not found! ***


### PR DESCRIPTION
### Motivation
- Goal: reduce the number of console windows spawned when the Task Scheduler runs the downloader → startup_tasks → common → tasks chain. 
- The existing self-relaunch and `START`-based child `cmd.exe` invocations were creating extra visible consoles, so the relaunch should remain disabled while documented.

### Description
- Commented-out the `SCRIPT_LOWPRIO` self-relaunch block in `startup/startup_tasks.bat` and added an explanatory note preserving the original low-priority `start` lines for reference.  
- Replaced the `start /wait ... cmd /c "%downloadDir%\common.bat"` invocation with `call "%downloadDir%\common.bat"` so `common.bat` runs in the current console instead of spawning a new window, while keeping the `start` variant commented.  
- Kept process-priority relaunch and priority-related code commented so the file documents the original approaches without creating extra windows.

### Testing
- Ran `git diff --check` with no reported issues.  
- Ran `git status --short` to verify the working tree state after the edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a436014b5088323a0f3bae82b7143c1)